### PR TITLE
Fix log directory and update dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,9 @@ import sys
 app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'fuel-blending-app-secret-key')
 
+# Ensure the log directory exists before configuring logging
+os.makedirs('logs', exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 dependencies = [
+    "flask",
+    "werkzeug",
     "pandas==2.2.2",
     "openpyxl==3.1.2",
-] 
+]


### PR DESCRIPTION
## Summary
- ensure logs directory exists before logging setup
- list flask and werkzeug dependencies

## Testing
- `python -m py_compile app.py`
- `pip install flask werkzeug pandas==2.2.2 openpyxl==3.1.2` *(fails: Cannot connect to proxy)*